### PR TITLE
feat: Integrate lm pool

### DIFF
--- a/contracts/StoryHuntV3Factory.sol
+++ b/contracts/StoryHuntV3Factory.sol
@@ -21,6 +21,11 @@ contract StoryHuntV3Factory is IStoryHuntV3Factory, StoryHuntV3PoolDeployer, NoD
     /// @inheritdoc IStoryHuntV3Factory
     mapping(address => mapping(address => mapping(uint24 => address))) public override getPool;
 
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
     constructor() {
         owner = msg.sender;
         emit OwnerChanged(address(0), msg.sender);
@@ -84,5 +89,9 @@ contract StoryHuntV3Factory is IStoryHuntV3Factory, StoryHuntV3PoolDeployer, NoD
 
         feeAmountTickSpacing[fee] = tickSpacing;
         emit FeeAmountEnabled(fee, tickSpacing);
+    }
+
+     function setLmPool(address pool, address lmPool) external override onlyOwner{
+        IStoryHuntV3Pool(pool).setLmPool(lmPool);
     }
 }

--- a/contracts/StoryHuntV3Factory.sol
+++ b/contracts/StoryHuntV3Factory.sol
@@ -7,6 +7,7 @@ import './StoryHuntV3PoolDeployer.sol';
 import './NoDelegateCall.sol';
 
 import './StoryHuntV3Pool.sol';
+import "hardhat/console.sol";
 
 /// @title Canonical StoryHunt V3 factory
 /// @notice Deploys StoryHunt V3 pools and manages ownership and control over pool protocol fees
@@ -24,8 +25,15 @@ contract StoryHuntV3Factory is IStoryHuntV3Factory, NoDelegateCall {
     /// @inheritdoc IStoryHuntV3Factory
     mapping(address => mapping(address => mapping(uint24 => address))) public override getPool;
 
+    address public lmPoolDeployer;
+
     modifier onlyOwner() {
         require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+     modifier onlyOwnerOrLmPoolDeployer() {
+        require(msg.sender == owner || msg.sender == lmPoolDeployer, "Not owner or LM pool deployer");
         _;
     }
 
@@ -95,7 +103,13 @@ contract StoryHuntV3Factory is IStoryHuntV3Factory, NoDelegateCall {
         emit FeeAmountEnabled(fee, tickSpacing);
     }
 
-     function setLmPool(address pool, address lmPool) external override onlyOwner{
+     function setLmPool(address pool, address lmPool) external override onlyOwnerOrLmPoolDeployer{
+        console.log("setLmPool", pool, lmPool);
         IStoryHuntV3Pool(pool).setLmPool(lmPool);
+    }
+
+    function setLmPoolDeployer(address _lmPoolDeployer) external override onlyOwner {
+        lmPoolDeployer = _lmPoolDeployer;
+        emit SetLmPoolDeployer(_lmPoolDeployer);
     }
 }

--- a/contracts/StoryHuntV3Factory.sol
+++ b/contracts/StoryHuntV3Factory.sol
@@ -10,9 +10,12 @@ import './StoryHuntV3Pool.sol';
 
 /// @title Canonical StoryHunt V3 factory
 /// @notice Deploys StoryHunt V3 pools and manages ownership and control over pool protocol fees
-contract StoryHuntV3Factory is IStoryHuntV3Factory, StoryHuntV3PoolDeployer, NoDelegateCall {
+contract StoryHuntV3Factory is IStoryHuntV3Factory, NoDelegateCall {
     /// @inheritdoc IStoryHuntV3Factory
     address public override owner;
+
+    address public immutable poolDeployer;
+
     // Added for two-step ownership transfer
     address private _pendingOwner;
 
@@ -26,7 +29,8 @@ contract StoryHuntV3Factory is IStoryHuntV3Factory, StoryHuntV3PoolDeployer, NoD
         _;
     }
 
-    constructor() {
+    constructor(address _poolDeployer) {
+        poolDeployer = _poolDeployer;
         owner = msg.sender;
         emit OwnerChanged(address(0), msg.sender);
 
@@ -50,7 +54,7 @@ contract StoryHuntV3Factory is IStoryHuntV3Factory, StoryHuntV3PoolDeployer, NoD
         int24 tickSpacing = feeAmountTickSpacing[fee];
         require(tickSpacing != 0);
         require(getPool[token0][token1][fee] == address(0));
-        pool = deploy(address(this), token0, token1, fee, tickSpacing);
+        pool = IStoryHuntV3PoolDeployer(poolDeployer).deploy(address(this), token0, token1, fee, tickSpacing);
         getPool[token0][token1][fee] = pool;
         // populate mapping in the reverse direction, deliberate choice to avoid the cost of comparing addresses
         getPool[token1][token0][fee] = pool;

--- a/contracts/StoryHuntV3Factory.sol
+++ b/contracts/StoryHuntV3Factory.sol
@@ -7,7 +7,6 @@ import './StoryHuntV3PoolDeployer.sol';
 import './NoDelegateCall.sol';
 
 import './StoryHuntV3Pool.sol';
-import "hardhat/console.sol";
 
 /// @title Canonical StoryHunt V3 factory
 /// @notice Deploys StoryHunt V3 pools and manages ownership and control over pool protocol fees
@@ -104,7 +103,6 @@ contract StoryHuntV3Factory is IStoryHuntV3Factory, NoDelegateCall {
     }
 
      function setLmPool(address pool, address lmPool) external override onlyOwnerOrLmPoolDeployer{
-        console.log("setLmPool", pool, lmPool);
         IStoryHuntV3Pool(pool).setLmPool(lmPool);
     }
 

--- a/contracts/StoryHuntV3Pool.sol
+++ b/contracts/StoryHuntV3Pool.sol
@@ -27,6 +27,9 @@ import './interfaces/callback/IStoryHuntV3MintCallback.sol';
 import './interfaces/callback/IStoryHuntV3SwapCallback.sol';
 import './interfaces/callback/IStoryHuntV3FlashCallback.sol';
 
+import "./interfaces/lmpool/ILMPool.sol";
+
+
 contract StoryHuntV3Pool is IStoryHuntV3Pool, NoDelegateCall {
     using LowGasSafeMath for uint256;
     using LowGasSafeMath for int256;
@@ -97,6 +100,11 @@ contract StoryHuntV3Pool is IStoryHuntV3Pool, NoDelegateCall {
     mapping(bytes32 => Position.Info) public override positions;
     /// @inheritdoc IStoryHuntV3PoolState
     Oracle.Observation[65535] public override observations;
+
+    // liquidity mining
+    IStoryHuntV3LmPool public lmPool;
+
+    event SetLmPoolEvent(address addr);
 
     /// @dev Mutually exclusive reentrancy protection into the pool to/from a method. This method also prevents entrance
     /// to a function before the pool is initialized. The reentrancy guard is required throughout the contract because
@@ -620,6 +628,10 @@ contract StoryHuntV3Pool is IStoryHuntV3Pool, NoDelegateCall {
             computedLatestObservation: false
         });
 
+        if (address(lmPool) != address(0)) {
+            lmPool.accumulateReward(cache.blockTimestamp);
+        }
+
         bool exactInput = amountSpecified > 0;
 
         SwapState memory state = SwapState({
@@ -701,6 +713,11 @@ contract StoryHuntV3Pool is IStoryHuntV3Pool, NoDelegateCall {
                         );
                         cache.computedLatestObservation = true;
                     }
+
+                    if (address(lmPool) != address(0)) {
+                        lmPool.crossLmTick(step.tickNext, zeroForOne);
+                    }
+
                     int128 liquidityNet = ticks.cross(
                         step.tickNext,
                         (zeroForOne ? state.feeGrowthGlobalX128 : feeGrowthGlobal0X128),
@@ -858,5 +875,11 @@ contract StoryHuntV3Pool is IStoryHuntV3Pool, NoDelegateCall {
         }
 
         emit CollectProtocol(msg.sender, recipient, amount0, amount1);
+    }
+
+    function setLmPool(address _lmPool) external override onlyFactoryOwner {
+        lmPool = IStoryHuntV3LmPool(_lmPool);
+
+        emit SetLmPoolEvent(_lmPool);
     }
 }

--- a/contracts/StoryHuntV3Pool.sol
+++ b/contracts/StoryHuntV3Pool.sol
@@ -117,8 +117,8 @@ contract StoryHuntV3Pool is IStoryHuntV3Pool, NoDelegateCall {
     }
 
     /// @dev Prevents calling a function from anyone except the address returned by IStoryHuntV3Factory#owner()
-    modifier onlyFactoryOwner() {
-        require(msg.sender == IStoryHuntV3Factory(factory).owner());
+    modifier onlyFactoryOrFactoryOwner() {
+        require(msg.sender == factory || msg.sender == IStoryHuntV3Factory(factory).owner());
         _;
     }
 
@@ -844,7 +844,7 @@ contract StoryHuntV3Pool is IStoryHuntV3Pool, NoDelegateCall {
     }
 
     /// @inheritdoc IStoryHuntV3PoolOwnerActions
-    function setFeeProtocol(uint8 feeProtocol0, uint8 feeProtocol1) external override lock onlyFactoryOwner {
+    function setFeeProtocol(uint8 feeProtocol0, uint8 feeProtocol1) external override lock onlyFactoryOrFactoryOwner {
         require(
             (feeProtocol0 == 0 || (feeProtocol0 >= 4 && feeProtocol0 <= 10)) &&
                 (feeProtocol1 == 0 || (feeProtocol1 >= 4 && feeProtocol1 <= 10))
@@ -859,7 +859,7 @@ contract StoryHuntV3Pool is IStoryHuntV3Pool, NoDelegateCall {
         address recipient,
         uint128 amount0Requested,
         uint128 amount1Requested
-    ) external override lock onlyFactoryOwner returns (uint128 amount0, uint128 amount1) {
+    ) external override lock onlyFactoryOrFactoryOwner returns (uint128 amount0, uint128 amount1) {
         amount0 = amount0Requested > protocolFees.token0 ? protocolFees.token0 : amount0Requested;
         amount1 = amount1Requested > protocolFees.token1 ? protocolFees.token1 : amount1Requested;
 
@@ -877,7 +877,7 @@ contract StoryHuntV3Pool is IStoryHuntV3Pool, NoDelegateCall {
         emit CollectProtocol(msg.sender, recipient, amount0, amount1);
     }
 
-    function setLmPool(address _lmPool) external override onlyFactoryOwner {
+    function setLmPool(address _lmPool) external override onlyFactoryOrFactoryOwner {
         lmPool = IStoryHuntV3LmPool(_lmPool);
 
         emit SetLmPoolEvent(_lmPool);

--- a/contracts/StoryHuntV3PoolDeployer.sol
+++ b/contracts/StoryHuntV3PoolDeployer.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.7.6;
 
-import './interfaces/IStoryHuntV3PoolDeployer.sol';
+import "./interfaces/IStoryHuntV3PoolDeployer.sol";
 
-import './StoryHuntV3Pool.sol';
+import "./StoryHuntV3Pool.sol";
 
 contract StoryHuntV3PoolDeployer is IStoryHuntV3PoolDeployer {
     struct Parameters {
@@ -16,6 +16,24 @@ contract StoryHuntV3PoolDeployer is IStoryHuntV3PoolDeployer {
 
     /// @inheritdoc IStoryHuntV3PoolDeployer
     Parameters public override parameters;
+
+    address public factoryAddress;
+
+    /// @notice Emitted when factory address is set
+    event SetFactoryAddress(address indexed factory);
+
+    modifier onlyFactory() {
+        require(msg.sender == factoryAddress, "only factory can call deploy");
+        _;
+    }
+
+    function setFactoryAddress(address _factoryAddress) external {
+        require(factoryAddress == address(0), "already initialized");
+
+        factoryAddress = _factoryAddress;
+
+        emit SetFactoryAddress(_factoryAddress);
+    }
 
     /// @dev Deploys a pool with the given parameters by transiently setting the parameters storage slot and then
     /// clearing it after deploying the pool.
@@ -30,9 +48,19 @@ contract StoryHuntV3PoolDeployer is IStoryHuntV3PoolDeployer {
         address token1,
         uint24 fee,
         int24 tickSpacing
-    ) internal returns (address pool) {
-        parameters = Parameters({factory: factory, token0: token0, token1: token1, fee: fee, tickSpacing: tickSpacing});
-        pool = address(new StoryHuntV3Pool{salt: keccak256(abi.encode(token0, token1, fee))}());
+    ) external override onlyFactory returns (address pool) {
+        parameters = Parameters({
+            factory: factory,
+            token0: token0,
+            token1: token1,
+            fee: fee,
+            tickSpacing: tickSpacing
+        });
+        pool = address(
+            new StoryHuntV3Pool{
+                salt: keccak256(abi.encode(token0, token1, fee))
+            }()
+        );
         delete parameters;
     }
 }

--- a/contracts/interfaces/IStoryHuntV3Factory.sol
+++ b/contracts/interfaces/IStoryHuntV3Factory.sol
@@ -75,4 +75,7 @@ interface IStoryHuntV3Factory {
     /// @param fee The fee amount to enable, denominated in hundredths of a bip (i.e. 1e-6)
     /// @param tickSpacing The spacing between ticks to be enforced for all pools created with the given fee amount
     function enableFeeAmount(uint24 fee, int24 tickSpacing) external;
+
+    function setLmPool(address pool, address lmPool) external;
+
 }

--- a/contracts/interfaces/IStoryHuntV3Factory.sol
+++ b/contracts/interfaces/IStoryHuntV3Factory.sol
@@ -33,6 +33,9 @@ interface IStoryHuntV3Factory {
     /// @param newOwner The newOwner that will accept the ownership
     event OwnershipTransferStarted(address indexed oldOwner, address indexed newOwner);
 
+    /// @notice Emitted when LM pool deployer is set
+    event SetLmPoolDeployer(address indexed lmPoolDeployer);
+
     /// @notice Returns the current owner of the factory
     /// @dev Can be changed by the current owner via transferOwnership and acceptOwnership
     /// @return The address of the factory owner
@@ -77,5 +80,7 @@ interface IStoryHuntV3Factory {
     function enableFeeAmount(uint24 fee, int24 tickSpacing) external;
 
     function setLmPool(address pool, address lmPool) external;
+
+    function setLmPoolDeployer(address _lmPoolDeployer) external;
 
 }

--- a/contracts/interfaces/IStoryHuntV3PoolDeployer.sol
+++ b/contracts/interfaces/IStoryHuntV3PoolDeployer.sol
@@ -16,5 +16,19 @@ interface IStoryHuntV3PoolDeployer {
     function parameters()
         external
         view
-        returns (address factory, address token0, address token1, uint24 fee, int24 tickSpacing);
+        returns (
+            address factory,
+            address token0,
+            address token1,
+            uint24 fee,
+            int24 tickSpacing
+        );
+
+    function deploy(
+        address factory,
+        address token0,
+        address token1,
+        uint24 fee,
+        int24 tickSpacing
+    ) external returns (address pool);
 }

--- a/contracts/interfaces/lmpool/ILMPool.sol
+++ b/contracts/interfaces/lmpool/ILMPool.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.7.6;
+
+interface IStoryHuntV3LmPool {
+    function accumulateReward(uint32 currTimestamp) external;
+
+    function crossLmTick(int24 tick, bool zeroForOne) external;
+}

--- a/contracts/interfaces/pool/IStoryHuntV3PoolOwnerActions.sol
+++ b/contracts/interfaces/pool/IStoryHuntV3PoolOwnerActions.sol
@@ -20,4 +20,7 @@ interface IStoryHuntV3PoolOwnerActions {
         uint128 amount0Requested,
         uint128 amount1Requested
     ) external returns (uint128 amount0, uint128 amount1);
+
+    /// @notice Set the LM pool to enable liquidity mining
+    function setLmPool(address lmPool) external;
 }

--- a/contracts/test/MockTimeStoryHuntV3PoolDeployer.sol
+++ b/contracts/test/MockTimeStoryHuntV3PoolDeployer.sol
@@ -24,7 +24,7 @@ contract MockTimeStoryHuntV3PoolDeployer is IStoryHuntV3PoolDeployer {
         address token1,
         uint24 fee,
         int24 tickSpacing
-    ) external returns (address pool) {
+    ) external override returns (address pool) {
         parameters = Parameters({factory: factory, token0: token0, token1: token1, fee: fee, tickSpacing: tickSpacing});
         pool = address(
             new MockTimeStoryHuntV3Pool{salt: keccak256(abi.encodePacked(token0, token1, fee, tickSpacing))}()


### PR DESCRIPTION
# summary of changes 
- [x] Replaced `StoryHuntV3PoolDeployer` inheritance with a separate deployed contract and introduced a poolDeployer setter
- [x] Add `IStoryHuntV3LmPool` callback functions into `v3-pool`
- [x] Setter and getter functions, modifiers for `lmPoolDeployer` and `poolDeployer` 

# Notes 
Seperate `StoryHuntV3PoolDeployer` to:
- reduce contract size for factory, so that we can run optimizer with high runs
- align with pancakeswap codebase

# TODO
- [ ] Update existing test cases of this repo (need setting / gas updated)